### PR TITLE
Parse time with en_US locale, set localized format with timeStyle

### DIFF
--- a/SDStatusBarManager/SDStatusBarManager.m
+++ b/SDStatusBarManager/SDStatusBarManager.m
@@ -152,8 +152,12 @@ typedef struct {
 
   // Set 9:41 time in current localization
   NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
-  [dateFormatter setDateFormat:NSLocalizedString(@"h:mm a",@"dateFormatter")];
-  NSDate *date = [dateFormatter dateFromString:NSLocalizedString(@"9:41 AM",@"dateString")];
+  dateFormatter.locale = [NSLocale localeWithLocaleIdentifier:@"en_US"];
+  [dateFormatter setDateFormat:@"h:mm a"];
+  NSDate *date = [dateFormatter dateFromString:@"9:41 AM"];
+  dateFormatter.locale = [NSLocale currentLocale];
+  dateFormatter.timeStyle = NSDateFormatterShortStyle;
+  dateFormatter.dateStyle = NSDateFormatterNoStyle;
   NSString *dateString = [NSString stringWithFormat:@"%@", [dateFormatter stringFromDate:date]];
   overrides->overrideTimeString = 1;
   strcpy(overrides->values.timeString, [dateString cStringUsingEncoding:NSUTF8StringEncoding]);


### PR DESCRIPTION
If running this with another locale than en_US, the parsing can fail. Then
when creating the localized time, you can't set the format to "h:mm a"
because that is not how a short time string is represented in many locales
(e.g it would produce "9:41 fm" in Swedish when it should really be just
"9:41"). Setting the timeStyle instead should take care of that.
