### PR TITLE
Support a minimum version of iOS 6.0

### DIFF
--- a/SimulatorStatusMagic.podspec
+++ b/SimulatorStatusMagic.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.author           = { "Dave Verwer" => "dave.verwer@shinydevelopment.com", "Greg Spiers" => "greg.spiers@shinydevelopment.com" }
   s.source           = { :git => "https://github.com/shinydevelopment/SimulatorStatusMagic.git", :tag => s.version.to_s }
 
-  s.platform     = :ios, '7.0'
+  s.platform     = :ios, '6.0'
   s.requires_arc = true
 
   s.source_files = 'SDStatusBarManager'


### PR DESCRIPTION
I work on an app that still needs to support iOS 6.1. I tried making our screenshots target have a different min version of iOS than the main target, but that seems to trigger an errorful edge case in Cocoapods. In my testing this change works great.
