### PR TITLE
Added ability to set a string as clock value. Better German localization.

### DIFF
--- a/SDStatusBarManager/SDStatusBarManager.h
+++ b/SDStatusBarManager/SDStatusBarManager.h
@@ -35,6 +35,8 @@ typedef NS_ENUM(NSInteger, SDStatusBarManagerBluetoothState)
 
 @property (copy, nonatomic) NSString* carrierName;
 
+@property (strong, nonatomic) NSString* timeString;
+
 @property (assign, nonatomic, readonly) BOOL usingOverrides;
 @property (assign, nonatomic) SDStatusBarManagerBluetoothState bluetoothState;
 

--- a/SDStatusBarManager/SDStatusBarManager.m
+++ b/SDStatusBarManager/SDStatusBarManager.m
@@ -29,6 +29,7 @@
 
 static NSString * const SDStatusBarManagerUsingOverridesKey = @"using_overrides";
 static NSString * const SDStatusBarManagerBluetoothStateKey = @"bluetooth_state";
+static NSString * const SDStatusBarManagerTimeStringKey = @"bluetooth_state";
 
 @interface SDStatusBarManager ()
 @property (nonatomic, strong) NSUserDefaults *userDefaults;
@@ -84,6 +85,16 @@ static NSString * const SDStatusBarManagerBluetoothStateKey = @"bluetooth_state"
   return [[self.userDefaults valueForKey:SDStatusBarManagerBluetoothStateKey] integerValue];
 }
 
+- (void)setTimeString:(NSString *)timeString {
+  if ([self.timeString isEqualToString:timeString]) return;
+  
+  [self.userDefaults setObject:timeString forKey:SDStatusBarManagerTimeStringKey];
+}
+- (NSString *)timeString {
+  return [self.userDefaults valueForKey:SDStatusBarManagerTimeStringKey];
+}
+
+
 - (NSUserDefaults *)userDefaults
 {
   if (!_userDefaults) {
@@ -108,6 +119,10 @@ static NSString * const SDStatusBarManagerBluetoothStateKey = @"bluetooth_state"
 #pragma mark Date helper
 - (NSString *)localizedTimeString
 {
+  if (![self.timeString isEqualToString:@""]) {
+    return self.timeString;
+  }
+  
   NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
   formatter.dateStyle = NSDateFormatterNoStyle;
   formatter.timeStyle = NSDateFormatterShortStyle;

--- a/SDStatusBarManager/SDStatusBarManager.m
+++ b/SDStatusBarManager/SDStatusBarManager.m
@@ -29,7 +29,7 @@
 
 static NSString * const SDStatusBarManagerUsingOverridesKey = @"using_overrides";
 static NSString * const SDStatusBarManagerBluetoothStateKey = @"bluetooth_state";
-static NSString * const SDStatusBarManagerTimeStringKey = @"bluetooth_state";
+static NSString * const SDStatusBarManagerTimeStringKey = @"timeString_state";
 
 @interface SDStatusBarManager ()
 @property (nonatomic, strong) NSUserDefaults *userDefaults;

--- a/SimulatorStatusMagic/Base.lproj/Main.storyboard
+++ b/SimulatorStatusMagic/Base.lproj/Main.storyboard
@@ -17,18 +17,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Omy-wd-t1z">
-                                <rect key="frame" x="178" y="284" width="244" height="32"/>
-                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                <state key="normal" title="Apply Clean Status Bar Overrides">
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                                </state>
-                                <connections>
-                                    <action selector="overrideButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="u6d-d9-0ab"/>
-                                </connections>
-                            </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Bluetooth Icon" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1W5-6m-qnr">
-                                <rect key="frame" x="247" y="28" width="106.5" height="19.5"/>
+                                <rect key="frame" x="247" y="28" width="107" height="20"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -48,29 +38,42 @@
                                 </connections>
                             </segmentedControl>
                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Text that will be displayed as clock" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="QuK-wD-2d0">
-                                <rect key="frame" x="150" y="142" width="300" height="30"/>
+                                <rect key="frame" x="150" y="143" width="300" height="30"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
+                                <textInputTraits key="textInputTraits" enablesReturnKeyAutomatically="YES"/>
+                                <connections>
+                                    <outlet property="delegate" destination="BYZ-38-t0r" id="nMZ-yv-GyM"/>
+                                </connections>
                             </textField>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="String Instead of Clock" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CcU-Mb-bVk">
-                                <rect key="frame" x="212" y="114" width="176" height="20.5"/>
+                                <rect key="frame" x="212" y="114" width="176" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Omy-wd-t1z">
+                                <rect key="frame" x="178" y="195" width="244" height="32"/>
+                                <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
+                                <state key="normal" title="Apply Clean Status Bar Overrides">
+                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                </state>
+                                <connections>
+                                    <action selector="overrideButtonTapped:" destination="BYZ-38-t0r" eventType="touchUpInside" id="u6d-d9-0ab"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="CcU-Mb-bVk" firstAttribute="top" secondItem="VEX-a6-wUU" secondAttribute="bottom" constant="30" id="06E-jA-9bB"/>
                             <constraint firstItem="VEX-a6-wUU" firstAttribute="top" secondItem="1W5-6m-qnr" secondAttribute="bottom" constant="8.5" id="6yr-PR-2Mv"/>
                             <constraint firstAttribute="centerX" secondItem="VEX-a6-wUU" secondAttribute="centerX" id="7k2-tb-Tvg"/>
-                            <constraint firstAttribute="centerY" secondItem="Omy-wd-t1z" secondAttribute="centerY" id="8oL-mN-lyb"/>
                             <constraint firstItem="VEX-a6-wUU" firstAttribute="trailing" secondItem="QuK-wD-2d0" secondAttribute="trailing" id="CH2-Pm-5xn"/>
                             <constraint firstItem="VEX-a6-wUU" firstAttribute="leading" secondItem="QuK-wD-2d0" secondAttribute="leading" id="DLs-vg-QzH"/>
                             <constraint firstItem="QuK-wD-2d0" firstAttribute="top" secondItem="CcU-Mb-bVk" secondAttribute="bottom" constant="8" id="GPW-yh-BfV"/>
                             <constraint firstItem="VEX-a6-wUU" firstAttribute="centerX" secondItem="QuK-wD-2d0" secondAttribute="centerX" id="Hji-Sf-pad"/>
                             <constraint firstAttribute="centerX" secondItem="1W5-6m-qnr" secondAttribute="centerX" constant="-0.5" id="Prz-cE-8oA"/>
                             <constraint firstItem="1W5-6m-qnr" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="8" id="Vqa-Qz-Ja3"/>
+                            <constraint firstItem="Omy-wd-t1z" firstAttribute="top" secondItem="QuK-wD-2d0" secondAttribute="bottom" constant="22" id="YAw-nZ-4Ni"/>
                             <constraint firstAttribute="centerX" secondItem="CcU-Mb-bVk" secondAttribute="centerX" id="qxc-YV-wRm"/>
                             <constraint firstAttribute="centerX" secondItem="Omy-wd-t1z" secondAttribute="centerX" id="xaa-SO-MPw"/>
                         </constraints>

--- a/SimulatorStatusMagic/Base.lproj/Main.storyboard
+++ b/SimulatorStatusMagic/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6245" systemVersion="14A388a" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
-        <deployment defaultVersion="1808" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6238"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
@@ -28,15 +28,15 @@
                                 </connections>
                             </button>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Bluetooth Icon" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1W5-6m-qnr">
-                                <rect key="frame" x="247" y="366" width="107" height="20"/>
+                                <rect key="frame" x="247" y="28" width="106.5" height="19.5"/>
                                 <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <segmentedControl opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="VEX-a6-wUU">
-                                <rect key="frame" x="150" y="394" width="300" height="29"/>
+                                <rect key="frame" x="150" y="56" width="300" height="29"/>
                                 <constraints>
-                                    <constraint firstAttribute="width" constant="300" id="Vei-lk-LDx"/>
+                                    <constraint firstAttribute="width" constant="300" id="ySp-lM-X7h"/>
                                 </constraints>
                                 <segments>
                                     <segment title="Hidden"/>
@@ -47,20 +47,38 @@
                                     <action selector="bluetoothStatusChanged:" destination="BYZ-38-t0r" eventType="valueChanged" id="67a-Ux-qau"/>
                                 </connections>
                             </segmentedControl>
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Text that will be displayed as clock" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="QuK-wD-2d0">
+                                <rect key="frame" x="150" y="142" width="300" height="30"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="String Instead of Clock" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="CcU-Mb-bVk">
+                                <rect key="frame" x="212" y="114" width="176" height="20.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstItem="VEX-a6-wUU" firstAttribute="centerX" secondItem="1W5-6m-qnr" secondAttribute="centerX" id="5kz-az-0iU"/>
-                            <constraint firstItem="1W5-6m-qnr" firstAttribute="centerX" secondItem="Omy-wd-t1z" secondAttribute="centerX" id="GHF-He-aJP"/>
-                            <constraint firstAttribute="centerY" secondItem="Omy-wd-t1z" secondAttribute="centerY" id="HwQ-bH-TKM"/>
-                            <constraint firstItem="1W5-6m-qnr" firstAttribute="top" secondItem="Omy-wd-t1z" secondAttribute="bottom" constant="50" id="I44-KL-yTT"/>
-                            <constraint firstItem="VEX-a6-wUU" firstAttribute="top" secondItem="1W5-6m-qnr" secondAttribute="bottom" constant="8" symbolic="YES" id="ZhL-bv-eFo"/>
-                            <constraint firstAttribute="centerX" secondItem="Omy-wd-t1z" secondAttribute="centerX" id="iu0-gd-7Jz"/>
+                            <constraint firstItem="CcU-Mb-bVk" firstAttribute="top" secondItem="VEX-a6-wUU" secondAttribute="bottom" constant="30" id="06E-jA-9bB"/>
+                            <constraint firstItem="VEX-a6-wUU" firstAttribute="top" secondItem="1W5-6m-qnr" secondAttribute="bottom" constant="8.5" id="6yr-PR-2Mv"/>
+                            <constraint firstAttribute="centerX" secondItem="VEX-a6-wUU" secondAttribute="centerX" id="7k2-tb-Tvg"/>
+                            <constraint firstAttribute="centerY" secondItem="Omy-wd-t1z" secondAttribute="centerY" id="8oL-mN-lyb"/>
+                            <constraint firstItem="VEX-a6-wUU" firstAttribute="trailing" secondItem="QuK-wD-2d0" secondAttribute="trailing" id="CH2-Pm-5xn"/>
+                            <constraint firstItem="VEX-a6-wUU" firstAttribute="leading" secondItem="QuK-wD-2d0" secondAttribute="leading" id="DLs-vg-QzH"/>
+                            <constraint firstItem="QuK-wD-2d0" firstAttribute="top" secondItem="CcU-Mb-bVk" secondAttribute="bottom" constant="8" id="GPW-yh-BfV"/>
+                            <constraint firstItem="VEX-a6-wUU" firstAttribute="centerX" secondItem="QuK-wD-2d0" secondAttribute="centerX" id="Hji-Sf-pad"/>
+                            <constraint firstAttribute="centerX" secondItem="1W5-6m-qnr" secondAttribute="centerX" constant="-0.5" id="Prz-cE-8oA"/>
+                            <constraint firstItem="1W5-6m-qnr" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" constant="8" id="Vqa-Qz-Ja3"/>
+                            <constraint firstAttribute="centerX" secondItem="CcU-Mb-bVk" secondAttribute="centerX" id="qxc-YV-wRm"/>
+                            <constraint firstAttribute="centerX" secondItem="Omy-wd-t1z" secondAttribute="centerX" id="xaa-SO-MPw"/>
                         </constraints>
                     </view>
                     <connections>
                         <outlet property="bluetoothSegmentedControl" destination="VEX-a6-wUU" id="L7z-KL-JJm"/>
                         <outlet property="overrideButton" destination="Omy-wd-t1z" id="OkF-TC-Syr"/>
+                        <outlet property="timeStringTextField" destination="QuK-wD-2d0" id="65v-sA-1Yd"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>

--- a/SimulatorStatusMagic/ViewController.h
+++ b/SimulatorStatusMagic/ViewController.h
@@ -24,6 +24,6 @@
 
 #import <UIKit/UIKit.h>
 
-@interface ViewController : UIViewController
+@interface ViewController : UIViewController <UITextFieldDelegate>
 
 @end

--- a/SimulatorStatusMagic/ViewController.m
+++ b/SimulatorStatusMagic/ViewController.m
@@ -93,4 +93,11 @@
   return UIStatusBarStyleDefault;
 }
 
+#pragma mark UITextFieldDelegate
+
+-(BOOL)textFieldShouldReturn:(UITextField *)textField {
+  [textField resignFirstResponder];
+  return YES;
+}
+
 @end

--- a/SimulatorStatusMagic/ViewController.m
+++ b/SimulatorStatusMagic/ViewController.m
@@ -25,8 +25,9 @@
 #import "ViewController.h"
 #import "SDStatusBarManager.h"
 
-@interface ViewController ()
+@interface ViewController () 
 @property (strong, nonatomic) IBOutlet UIButton *overrideButton;
+@property (weak, nonatomic) IBOutlet UITextField *timeStringTextField;
 @property (strong, nonatomic) IBOutlet UISegmentedControl *bluetoothSegmentedControl;
 @end
 
@@ -39,6 +40,7 @@
 
   [self setOverrideButtonText];
   [self setBluetoothSegementedControlSelectedSegment];
+  [self setTimeStringTextFieldText];
 }
 
 #pragma mark Actions
@@ -48,6 +50,8 @@
     [[SDStatusBarManager sharedInstance] disableOverrides];
     [self setOverrideButtonText];
   } else {
+    [SDStatusBarManager sharedInstance].timeString = self.timeStringTextField.text;
+    
     [[SDStatusBarManager sharedInstance] enableOverrides];
     [self setOverrideButtonText];
   }
@@ -73,6 +77,9 @@
 {
   // Note: The order of the segments should match the definition of SDStatusBarManagerBluetoothState
   self.bluetoothSegmentedControl.selectedSegmentIndex = [SDStatusBarManager sharedInstance].bluetoothState;
+}
+- (void)setTimeStringTextFieldText {
+  self.timeStringTextField.text = [SDStatusBarManager sharedInstance].timeString;
 }
 
 #pragma mark Status bar settings

--- a/SimulatorStatusMagic/de.lproj/Main.strings
+++ b/SimulatorStatusMagic/de.lproj/Main.strings
@@ -1,3 +1,20 @@
+/* Class = "UILabel"; text = "Bluetooth Icon"; ObjectID = "1W5-6m-qnr"; */
+"1W5-6m-qnr.text" = "Bluetooth Icon";
 
-/* Class = "IBUIButton"; normalTitle = "Apply Clean Status Bar Overrides"; ObjectID = "Omy-wd-t1z"; */
+/* Class = "UILabel"; text = "String instead of clock"; ObjectID = "CcU-Mb-bVk"; */
+"CcU-Mb-bVk.text" = "Text als Uhrzeit";
+
+/* Class = "UIButton"; normalTitle = "Apply Clean Status Bar Overrides"; ObjectID = "Omy-wd-t1z"; */
 "Omy-wd-t1z.normalTitle" = "Statusleiste mit Clean Status Bar überschreiben";
+
+/* Class = "UITextField"; placeholder = "Text that will be displayed as clock"; ObjectID = "QuK-wD-2d0"; */
+"QuK-wD-2d0.placeholder" = "Text, der anstelle der Uhrzeit angezeigt wird";
+
+/* Class = "UISegmentedControl"; VEX-a6-wUU.segmentTitles[0] = "Hidden"; ObjectID = "VEX-a6-wUU"; */
+"VEX-a6-wUU.segmentTitles[0]" = "Kein Bluetooth";
+
+/* Class = "UISegmentedControl"; VEX-a6-wUU.segmentTitles[1] = "Dimmed"; ObjectID = "VEX-a6-wUU"; */
+"VEX-a6-wUU.segmentTitles[1]" = "Nicht Verbunden";
+
+/* Class = "UISegmentedControl"; VEX-a6-wUU.segmentTitles[2] = "Connected"; ObjectID = "VEX-a6-wUU"; */
+"VEX-a6-wUU.segmentTitles[2]" = "Verbunden";


### PR DESCRIPTION

In many cases, you want to create screenshots for different languages.

One possible solution is to change the language of the simulator.
Another way is to use a scheme that sets a certain launch argument (as
described in this post:
http://useyourloaf.com/blog/2013/07/22/using-launch-arguments-to-test-lo
calizations.html ).

The second method is way faster and the approach that I prefer,
due to the fact, that it does not require the simulator to re-load
springboard to change the entire system language.

However, the string "09:41" is not accurate (for instance) in German (we
use "09:41") so I want to use my own time format.

I extended the project in a way you can set the value you like without
having to wait until the simulator has changed the system language (not
to mention the clicks needed to get into the language menu).