### PR TITLE
[fix] SDStatusBarManager timeString

### DIFF
--- a/SDStatusBarManager/SDStatusBarManager.m
+++ b/SDStatusBarManager/SDStatusBarManager.m
@@ -126,7 +126,7 @@ static NSString * const SDStatusBarManagerTimeStringKey = @"time_string";
 #pragma mark Date helper
 - (NSString *)localizedTimeString
 {
-  if (![self.timeString isEqualToString:@""]) {
+  if (self.timeString.length) {
     return self.timeString;
   }
   


### PR DESCRIPTION
I am using Xcode 6.4 beta 4 and if don't set `timeString` explicitly, it crashes at [this](https://github.com/shinydevelopment/SimulatorStatusMagic/blob/master/SDStatusBarManager/SDStatusBarOverriderPost8_3.m#L114) line because `timeString` is nil.