### PR TITLE
Delete vestigial comment.

### DIFF
--- a/SDStatusBarManager/SDStatusBarOverriderPost9_3.m
+++ b/SDStatusBarManager/SDStatusBarOverriderPost9_3.m
@@ -121,7 +121,6 @@ typedef struct {
 
 @interface UIStatusBarServer : NSObject {
   struct __CFRunLoopSource { } * _source;
-  //<UIStatusBarServerClient> * _statusBar;
   id<UIStatusBarServerClient> _statusBar;
 }
 


### PR DESCRIPTION
It was throwing a "Not a Doxygen trailing comment" warning in Xcode 8.3.2.