### PR TITLE
Add BITCODE_GENERATION_MODE user defined setting.

### DIFF
--- a/SimulatorStatusMagic.xcodeproj/project.pbxproj
+++ b/SimulatorStatusMagic.xcodeproj/project.pbxproj
@@ -549,6 +549,7 @@
 		72ECF73F1BAAC33A0071D401 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BITCODE_GENERATION_MODE = marker;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
@@ -575,6 +576,7 @@
 		72ECF7401BAAC33A0071D401 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BITCODE_GENERATION_MODE = bitcode;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;


### PR DESCRIPTION
This ensures that generated framework will be correctly built with bitcode for archiving and submitting to Apple.
Source: https://medium.com/@heitorburger/static-libraries-frameworks-and-bitcode-6d8f784478a9
Source: http://stackoverflow.com/a/34965178

This change is necessary when creating a Release build of SimulatorStatusMagiciOS.framework, then adding manually to a project (not via Carthage or CocoaPods).
In order to use the framework in a Debug build (ie for automation of screenshots), the framework must be linked and also embedded within project.
If bitcode is enabled for the project, all embedded frameworks must also contain bitcode, hence the requirement that SimulatorStatusMagiciOS.framework generates bitcode.
Note: SimulatorStatusMagiciOS.framework is only invoked in Debug build, not Release build, but xcode currently has no built-in method for embedding frameworks based on configuration.
Source: https://forums.developer.apple.com/thread/95424