### PR TITLE
Elaborate installation instructions for 'without a dependency manager'

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -39,3 +39,15 @@ SimulatorStatusMagic can also be included as a dynamic framework by following st
 * Download the source code and open the XCode project
 * Run the target `SimulatorStatusMagicUniversalFramework` which generates a universal framework for both device and simulator.
 * Drag and drop the generated framework into your project.
+
+Note that SimulatorStatusMagic calls non-public APIs and should not be submitted to the app store. If you wish to add SimulatorStatusMagic for Debug configuration only, follow these steps:
+
+* Ensure that SimulatorStatusMagiciOS.framework is within your project folder, but not added to any project target
+* In app target Build Settings, expand the Framework Search Paths and add the framework's containing folder in the Debug configuration. For example, `$(SRCROOT)/ThirdPartyFrameworks/`
+* Now you should be able to import and compile with SimulatorStatusMagiciOS, but app will crash with error:
+`dyld: Library not loaded: @rpath/SimulatorStatusMagiciOS.framework/SimulatorStatusMagiciOS`
+* To solve this, open app target's Build Phases and click the + icon then select New Run Script Phase
+* Configure Run Script phase to embed SimulatorStatusMagiciOS.framework only when Debug configuration is used
+ * Use the script `embed-debug-only-framework.sh` that is [available here](https://gist.github.com/kenthumphries/cf04683184217c7331f9c213c556c65a)
+
+Now that SimilatorStatusMagic is added only for Debug configuration, you must ensure that any imports or calls to SDStatusBarManager are made between `#if DEBUG` and `#endif`.


### PR DESCRIPTION
Adds installation instructions for users wishing to add SimulatorStatusMagiciOS without a dependency manager. Instructions give advice on adding the framework only when app is built in Debug configuration.

This references a shell script I have made available as a public gist here: https://gist.github.com/kenthumphries/cf04683184217c7331f9c213c556c65a

I previously raised a PR to add bitcode support, but this was a mistake as the framework also contains non public APIs. It was also a poor choice on my part to try shipping a Debug only framework! 😳
This solution solves the problem in a manner similar (albeit simplified) to Carthage.