### PR TITLE
Update for iOS 12b5

### DIFF
--- a/SDStatusBarManager/SDStatusBarOverriderPost12_0.m
+++ b/SDStatusBarManager/SDStatusBarOverriderPost12_0.m
@@ -52,7 +52,7 @@ typedef NS_ENUM(unsigned int, BatteryState) {
 };
 
 typedef struct {
-  bool itemIsEnabled[36];
+  bool itemIsEnabled[37];
   char timeString[64];
   char shortTimeString[64];
   char dateString[256];
@@ -95,7 +95,7 @@ typedef struct {
 } StatusBarRawData;
 
 typedef struct {
-  bool overrideItemIsEnabled[36];
+  bool overrideItemIsEnabled[37];
   unsigned int overrideTimeString : 1;
   unsigned int overrideDateString : 1;
   unsigned int overrideGsmSignalStrengthRaw : 1;


### PR DESCRIPTION
It looks like this changed a bit in a later beta. 🙁 

I've been sitting on this because I also noticed that the bluetooth indicator setting has stopped being applied but I haven't gotten time to figure that out and fixing the rest of the things is better than nothing.