### PR TITLE
iPad on iOS 12 (date and GSM signal)

### DIFF
--- a/SDStatusBarManager/SDStatusBarManager.h
+++ b/SDStatusBarManager/SDStatusBarManager.h
@@ -49,6 +49,8 @@ typedef NS_ENUM(NSInteger, SDStatusBarManagerNetworkType)
 @property (assign, nonatomic) SDStatusBarManagerBluetoothState bluetoothState;
 @property (assign, nonatomic) SDStatusBarManagerNetworkType networkType;
 @property (assign, nonatomic) BOOL batteryDetailEnabled;
+@property (assign, nonatomic) BOOL iPadDateEnabled;
+@property (assign, nonatomic) BOOL iPadGsmSignalEnabled;
 
 - (void)enableOverrides;
 - (void)disableOverrides;

--- a/SDStatusBarManager/SDStatusBarManager.m
+++ b/SDStatusBarManager/SDStatusBarManager.m
@@ -54,6 +54,8 @@ static NSString * const SDStatusBarManagerTimeStringKey = @"time_string";
   if (self) {
     // Set any defaults for the status bar
     self.batteryDetailEnabled = YES;
+    self.iPadDateEnabled = NO;
+    self.iPadGsmSignalEnabled = NO;
   }
   return self;
 }
@@ -68,6 +70,8 @@ static NSString * const SDStatusBarManagerTimeStringKey = @"time_string";
   self.overrider.bluetoothConnected = self.bluetoothState == SDStatusBarManagerBluetoothVisibleConnected;
   self.overrider.batteryDetailEnabled = self.batteryDetailEnabled;
   self.overrider.networkType = self.networkType;
+  self.overrider.iPadDateEnabled = self.iPadDateEnabled;
+  self.overrider.iPadGsmSignalEnabled = self.iPadGsmSignalEnabled;
 
   [self.overrider enableOverrides];
 }

--- a/SDStatusBarManager/SDStatusBarOverrider.h
+++ b/SDStatusBarManager/SDStatusBarOverrider.h
@@ -35,6 +35,8 @@
 @property (assign, nonatomic) BOOL bluetoothConnected;
 @property (assign, nonatomic) BOOL batteryDetailEnabled;
 @property (assign, nonatomic) SDStatusBarManagerNetworkType networkType;
+@property (assign, nonatomic) BOOL iPadDateEnabled;
+@property (assign, nonatomic) BOOL iPadGsmSignalEnabled;
 
 - (void)enableOverrides;
 - (void)disableOverrides;

--- a/SDStatusBarManager/SDStatusBarOverriderPost10_0.m
+++ b/SDStatusBarManager/SDStatusBarOverriderPost10_0.m
@@ -174,6 +174,8 @@ typedef struct {
 @synthesize bluetoothEnabled;
 @synthesize batteryDetailEnabled;
 @synthesize networkType;
+@synthesize iPadDateEnabled;
+@synthesize iPadGsmSignalEnabled;
 
 - (void)enableOverrides
 {

--- a/SDStatusBarManager/SDStatusBarOverriderPost10_3.m
+++ b/SDStatusBarManager/SDStatusBarOverriderPost10_3.m
@@ -152,6 +152,8 @@ typedef struct {
 @synthesize bluetoothEnabled;
 @synthesize batteryDetailEnabled;
 @synthesize networkType;
+@synthesize iPadDateEnabled;
+@synthesize iPadGsmSignalEnabled;
 
 - (void)enableOverrides {
   StatusBarOverrideData *overrides = [UIStatusBarServer getStatusBarOverrideData];

--- a/SDStatusBarManager/SDStatusBarOverriderPost11_0.m
+++ b/SDStatusBarManager/SDStatusBarOverriderPost11_0.m
@@ -155,6 +155,8 @@ typedef struct {
 @synthesize bluetoothEnabled;
 @synthesize batteryDetailEnabled;
 @synthesize networkType;
+@synthesize iPadDateEnabled;
+@synthesize iPadGsmSignalEnabled;
 
 - (void)enableOverrides {
   StatusBarOverrideData *overrides = [UIStatusBarServer getStatusBarOverrideData];

--- a/SDStatusBarManager/SDStatusBarOverriderPost12_0.m
+++ b/SDStatusBarManager/SDStatusBarOverriderPost12_0.m
@@ -11,12 +11,12 @@
 
 typedef NS_ENUM(int, StatusBarItem) {
   // 0
-  // 1
+  dateStringIpad = 1,
   // 2
   // 3
   SignalStrengthBars = 4,
   SecondarySignalStrengthBars = 5,
-  // 6
+  SignalStrengthBarsVisibleOnIpad = 6,
   // 7
   // 8
   // 9
@@ -179,6 +179,8 @@ typedef struct {
 @synthesize bluetoothEnabled;
 @synthesize batteryDetailEnabled;
 @synthesize networkType;
+@synthesize iPadDateEnabled;
+@synthesize iPadGsmSignalEnabled;
 
 - (void)enableOverrides {
   StatusBarOverrideData *overrides = [UIStatusBarServer getStatusBarOverrideData];
@@ -186,6 +188,12 @@ typedef struct {
   // Set 9:41 time in current localization
   strcpy(overrides->values.timeString, [self.timeString cStringUsingEncoding:NSUTF8StringEncoding]);
   overrides->overrideTimeString = 1;
+  
+  // Show / Hide date on iPad
+  if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+    overrides->overrideItemIsEnabled[dateStringIpad] = 1;
+    overrides->values.itemIsEnabled[dateStringIpad] = self.iPadDateEnabled ? 1 : 0;
+  }
 
   // Enable 5 bars of mobile (iPhone only)
   if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPhone) {
@@ -193,6 +201,19 @@ typedef struct {
     overrides->values.itemIsEnabled[SignalStrengthBars] = 1;
     overrides->overrideGsmSignalStrengthBars = 1;
     overrides->values.gsmSignalStrengthBars = 5;
+  }
+  
+  // Enable / Disable GSM signal bars on iPad
+  if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+    if (self.iPadGsmSignalEnabled) {
+      overrides->overrideItemIsEnabled[SignalStrengthBars] = 1;
+      overrides->values.itemIsEnabled[SignalStrengthBars] = 1;
+      overrides->overrideGsmSignalStrengthBars = 1;
+      overrides->values.gsmSignalStrengthBars = 5;
+    } else {
+      overrides->overrideItemIsEnabled[SignalStrengthBarsVisibleOnIpad] = 1;
+      overrides->values.itemIsEnabled[SignalStrengthBars] = 0;
+    }
   }
 
   overrides->overrideDataNetworkType = self.networkType != SDStatusBarManagerNetworkTypeWiFi;

--- a/SDStatusBarManager/SDStatusBarOverriderPost8_3.m
+++ b/SDStatusBarManager/SDStatusBarOverriderPost8_3.m
@@ -122,6 +122,8 @@ typedef struct {
 @synthesize bluetoothEnabled;
 @synthesize batteryDetailEnabled;
 @synthesize networkType;
+@synthesize iPadDateEnabled;
+@synthesize iPadGsmSignalEnabled;
 
 - (void)enableOverrides
 {

--- a/SDStatusBarManager/SDStatusBarOverriderPost9_0.m
+++ b/SDStatusBarManager/SDStatusBarOverriderPost9_0.m
@@ -123,6 +123,8 @@ typedef struct {
 @synthesize bluetoothEnabled;
 @synthesize batteryDetailEnabled;
 @synthesize networkType;
+@synthesize iPadDateEnabled;
+@synthesize iPadGsmSignalEnabled;
 
 - (void)enableOverrides
 {

--- a/SDStatusBarManager/SDStatusBarOverriderPost9_3.m
+++ b/SDStatusBarManager/SDStatusBarOverriderPost9_3.m
@@ -170,6 +170,8 @@ typedef struct {
 @synthesize bluetoothEnabled;
 @synthesize batteryDetailEnabled;
 @synthesize networkType;
+@synthesize iPadDateEnabled;
+@synthesize iPadGsmSignalEnabled;
 
 - (void)enableOverrides
 {

--- a/SDStatusBarManager/SDStatusBarOverriderPre8_3.m
+++ b/SDStatusBarManager/SDStatusBarOverriderPre8_3.m
@@ -122,6 +122,8 @@ typedef struct {
 @synthesize bluetoothEnabled;
 @synthesize batteryDetailEnabled;
 @synthesize networkType;
+@synthesize iPadDateEnabled;
+@synthesize iPadGsmSignalEnabled;
 
 - (void)enableOverrides
 {


### PR DESCRIPTION
I've added the following:

support to show/hide date on iPad on iOS 12 (not shown by default)

support to show / hide the GSM signal bars on iPad on iOS 12 (not shown by default)

hope it's useful contribution to this powerful tool.

Best Regards,
Moustafa Hassan