### PR TITLE
fix implementation of show / hide battery details on iOS 12

### DIFF
--- a/SDStatusBarManager/SDStatusBarOverriderPost12_0.m
+++ b/SDStatusBarManager/SDStatusBarOverriderPost12_0.m
@@ -208,14 +208,13 @@ typedef struct {
 
   // Battery: 100% and unplugged
   overrides->overrideItemIsEnabled[BatteryDetail] = YES;
-  overrides->values.itemIsEnabled[BatteryDetail] = YES;
+  overrides->values.itemIsEnabled[BatteryDetail] = self.batteryDetailEnabled;
   overrides->overrideBatteryCapacity = YES;
   overrides->values.batteryCapacity = 100;
   overrides->overrideBatteryState = YES;
   overrides->values.batteryState = BatteryStateUnplugged;
   overrides->overrideBatteryDetailString = YES;
-  NSString *batteryDetailString = self.batteryDetailEnabled ? [NSString stringWithFormat:@"%@%%", @(overrides->values.batteryCapacity)] : @" ";
-  // Setting this to an empty string will not work, it needs to be a @" "
+  NSString *batteryDetailString = [NSString stringWithFormat:@"%@%%", @(overrides->values.batteryCapacity)];
   strcpy(overrides->values.batteryDetailString, [batteryDetailString cStringUsingEncoding:NSUTF8StringEncoding]);
 
   // Bluetooth
@@ -228,13 +227,6 @@ typedef struct {
 
   // Actually update the status bar
   [UIStatusBarServer postStatusBarOverrideData:overrides];
-
-  // Remove the @" " used to trick the battery percentage into not showing, if used
-  if (!self.batteryDetailEnabled) {
-    batteryDetailString = @"";
-    strcpy(overrides->values.batteryDetailString, [batteryDetailString cStringUsingEncoding:NSUTF8StringEncoding]);
-    [UIStatusBarServer postStatusBarOverrideData:overrides];
-  }
 
   // Lock in the changes, reset simulator will remove this
   [UIStatusBarServer permanentizeStatusBarOverrideData];


### PR DESCRIPTION
the current implementation for hiding battery percentage seems not working on iOS 12

so I found a simpler and better implementation to hide battery percentage.

hope it will be useful addition to this powerful tool

Best Regards,
Moustafa Hassan