### PR TITLE
Support overriding the date on iPad, fix #72

### DIFF
--- a/SDStatusBarManager/SDStatusBarManager.h
+++ b/SDStatusBarManager/SDStatusBarManager.h
@@ -45,6 +45,7 @@ typedef NS_ENUM(NSInteger, SDStatusBarManagerNetworkType)
 
 @property (copy, nonatomic) NSString *carrierName;
 @property (copy, nonatomic) NSString *timeString;
+@property (copy, nonatomic) NSString *dateString;
 @property (assign, nonatomic, readonly) BOOL usingOverrides;
 @property (assign, nonatomic) SDStatusBarManagerBluetoothState bluetoothState;
 @property (assign, nonatomic) SDStatusBarManagerNetworkType networkType;

--- a/SDStatusBarManager/SDStatusBarManager.m
+++ b/SDStatusBarManager/SDStatusBarManager.m
@@ -38,6 +38,7 @@ static NSString * const SDStatusBarManagerBluetoothStateKey = @"bluetooth_state"
 static NSString * const SDStatusBarManagerNetworkTypeKey = @"network_type";
 static NSString * const SDStatusBarManagerCarrierNameKey = @"carrier_name";
 static NSString * const SDStatusBarManagerTimeStringKey = @"time_string";
+static NSString * const SDStatusBarManagerDateStringKey = @"date_string";
 
 @interface SDStatusBarManager ()
 
@@ -54,7 +55,7 @@ static NSString * const SDStatusBarManagerTimeStringKey = @"time_string";
   if (self) {
     // Set any defaults for the status bar
     self.batteryDetailEnabled = YES;
-    self.iPadDateEnabled = NO;
+    self.iPadDateEnabled = YES;
     self.iPadGsmSignalEnabled = NO;
   }
   return self;
@@ -65,6 +66,7 @@ static NSString * const SDStatusBarManagerTimeStringKey = @"time_string";
   self.usingOverrides = YES;
 
   self.overrider.timeString = [self localizedTimeString];
+  self.overrider.dateString = [self localizedDateString];
   self.overrider.carrierName = self.carrierName;
   self.overrider.bluetoothEnabled = self.bluetoothState != SDStatusBarManagerBluetoothHidden;
   self.overrider.bluetoothConnected = self.bluetoothState == SDStatusBarManagerBluetoothVisibleConnected;
@@ -158,6 +160,21 @@ static NSString * const SDStatusBarManagerTimeStringKey = @"time_string";
   return [self.userDefaults valueForKey:SDStatusBarManagerTimeStringKey];
 }
 
+- (void)setDateString:(NSString *)dateString {
+  if ([self.dateString isEqualToString:dateString]) return;
+  
+  [self.userDefaults setObject:dateString forKey:SDStatusBarManagerDateStringKey];
+  
+  if (self.usingOverrides) {
+    [self enableOverrides];
+  }
+}
+
+- (NSString *)dateString
+{
+  return [self.userDefaults valueForKey:SDStatusBarManagerDateStringKey];
+}
+
 - (NSUserDefaults *)userDefaults
 {
   if (!_userDefaults) {
@@ -214,6 +231,23 @@ static NSString * const SDStatusBarManagerTimeStringKey = @"time_string";
   components.hour = 9;
   components.minute = 41;
 
+  return [formatter stringFromDate:[[NSCalendar currentCalendar] dateFromComponents:components]];
+}
+
+- (NSString *)localizedDateString
+{
+  if (self.dateString.length > 0) {
+    return self.dateString;
+  }
+  
+  NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
+  formatter.dateFormat = [[NSDateFormatter dateFormatFromTemplate:@"EEE MMM d" options:0 locale:NSLocale.currentLocale] stringByReplacingOccurrencesOfString:@"," withString:@""];
+  
+  NSDateComponents *components = [[NSCalendar currentCalendar] components:  NSCalendarUnitHour | NSCalendarUnitMinute | NSCalendarUnitSecond fromDate:[NSDate date]];
+  components.day = 9;
+  components.month = 1;
+  components.year = 2007;
+  
   return [formatter stringFromDate:[[NSCalendar currentCalendar] dateFromComponents:components]];
 }
 

--- a/SDStatusBarManager/SDStatusBarOverrider.h
+++ b/SDStatusBarManager/SDStatusBarOverrider.h
@@ -29,6 +29,7 @@
 @protocol SDStatusBarOverrider <NSObject>
 
 @property (copy, nonatomic) NSString *timeString;
+@property (copy, nonatomic) NSString *dateString;
 @property (copy, nonatomic) NSString* carrierName;
 
 @property (assign, nonatomic) BOOL bluetoothEnabled;

--- a/SDStatusBarManager/SDStatusBarOverriderPost10_0.m
+++ b/SDStatusBarManager/SDStatusBarOverriderPost10_0.m
@@ -169,6 +169,7 @@ typedef struct {
 @implementation SDStatusBarOverriderPost10_0
 
 @synthesize timeString;
+@synthesize dateString;
 @synthesize carrierName;
 @synthesize bluetoothConnected;
 @synthesize bluetoothEnabled;

--- a/SDStatusBarManager/SDStatusBarOverriderPost10_3.m
+++ b/SDStatusBarManager/SDStatusBarOverriderPost10_3.m
@@ -147,6 +147,7 @@ typedef struct {
 @implementation SDStatusBarOverriderPost10_3
 
 @synthesize timeString;
+@synthesize dateString;
 @synthesize carrierName;
 @synthesize bluetoothConnected;
 @synthesize bluetoothEnabled;

--- a/SDStatusBarManager/SDStatusBarOverriderPost11_0.m
+++ b/SDStatusBarManager/SDStatusBarOverriderPost11_0.m
@@ -150,6 +150,7 @@ typedef struct {
 @implementation SDStatusBarOverriderPost11_0
 
 @synthesize timeString;
+@synthesize dateString;
 @synthesize carrierName;
 @synthesize bluetoothConnected;
 @synthesize bluetoothEnabled;

--- a/SDStatusBarManager/SDStatusBarOverriderPost12_0.m
+++ b/SDStatusBarManager/SDStatusBarOverriderPost12_0.m
@@ -174,6 +174,7 @@ typedef struct {
 @implementation SDStatusBarOverriderPost12_0
 
 @synthesize timeString;
+@synthesize dateString;
 @synthesize carrierName;
 @synthesize bluetoothConnected;
 @synthesize bluetoothEnabled;
@@ -188,6 +189,10 @@ typedef struct {
   // Set 9:41 time in current localization
   strcpy(overrides->values.timeString, [self.timeString cStringUsingEncoding:NSUTF8StringEncoding]);
   overrides->overrideTimeString = 1;
+  
+  // Set Tue Jan 9 in current localization
+  strcpy(overrides->values.dateString, [self.dateString cStringUsingEncoding:NSUTF8StringEncoding]);
+  overrides->overrideDateString = 1;
   
   // Show / Hide date on iPad
   if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) {
@@ -262,6 +267,7 @@ typedef struct {
 
   // Remove specific overrides (separate flags)
   overrides->overrideTimeString = 0;
+  overrides->overrideDateString = 0;
   overrides->overrideGsmSignalStrengthBars = 0;
   overrides->overrideDataNetworkType = 0;
   overrides->overrideBatteryCapacity = 0;

--- a/SDStatusBarManager/SDStatusBarOverriderPost8_3.m
+++ b/SDStatusBarManager/SDStatusBarOverriderPost8_3.m
@@ -117,6 +117,7 @@ typedef struct {
 @implementation SDStatusBarOverriderPost8_3
 
 @synthesize timeString;
+@synthesize dateString;
 @synthesize carrierName;
 @synthesize bluetoothConnected;
 @synthesize bluetoothEnabled;

--- a/SDStatusBarManager/SDStatusBarOverriderPost9_0.m
+++ b/SDStatusBarManager/SDStatusBarOverriderPost9_0.m
@@ -118,6 +118,7 @@ typedef struct {
 @implementation SDStatusBarOverriderPost9_0
 
 @synthesize timeString;
+@synthesize dateString;
 @synthesize carrierName;
 @synthesize bluetoothConnected;
 @synthesize bluetoothEnabled;

--- a/SDStatusBarManager/SDStatusBarOverriderPost9_3.m
+++ b/SDStatusBarManager/SDStatusBarOverriderPost9_3.m
@@ -165,6 +165,7 @@ typedef struct {
 @implementation SDStatusBarOverriderPost9_3
 
 @synthesize timeString;
+@synthesize dateString;
 @synthesize carrierName;
 @synthesize bluetoothConnected;
 @synthesize bluetoothEnabled;

--- a/SDStatusBarManager/SDStatusBarOverriderPre8_3.m
+++ b/SDStatusBarManager/SDStatusBarOverriderPre8_3.m
@@ -117,6 +117,7 @@ typedef struct {
 @implementation SDStatusBarOverriderPre8_3
 
 @synthesize timeString;
+@synthesize dateString;
 @synthesize carrierName;
 @synthesize bluetoothConnected;
 @synthesize bluetoothEnabled;

--- a/SimulatorStatusMagic/Base.lproj/Main.storyboard
+++ b/SimulatorStatusMagic/Base.lproj/Main.storyboard
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -23,7 +22,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="xyG-Pn-i6h">
-                                <rect key="frame" x="36" y="40" width="303" height="327"/>
+                                <rect key="frame" x="36" y="40" width="303" height="401.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Bluetooth Icon" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="62A-L5-iwF">
                                         <rect key="frame" x="0.0" y="0.0" width="303" height="20.5"/>
@@ -92,8 +91,24 @@
                                             <outlet property="delegate" destination="BYZ-38-t0r" id="pAl-PL-KXu"/>
                                         </connections>
                                     </textField>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Date" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="eIb-YX-XaO">
+                                        <rect key="frame" x="0.0" y="294" width="303" height="20.5"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                        <nil key="textColor"/>
+                                        <nil key="highlightedColor"/>
+                                    </label>
+                                    <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Tue Jan 9" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="SDw-De-k5w">
+                                        <rect key="frame" x="0.0" y="326.5" width="303" height="30"/>
+                                        <nil key="textColor"/>
+                                        <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                        <textInputTraits key="textInputTraits"/>
+                                        <connections>
+                                            <action selector="dateStringTextFieldEditingChanged:" destination="BYZ-38-t0r" eventType="editingChanged" id="kuV-Nn-JHv"/>
+                                            <outlet property="delegate" destination="BYZ-38-t0r" id="wo8-rI-sM3"/>
+                                        </connections>
+                                    </textField>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="w0W-Cx-jCM">
-                                        <rect key="frame" x="0.0" y="294" width="303" height="33"/>
+                                        <rect key="frame" x="0.0" y="368.5" width="303" height="33"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                         <state key="normal" title="Apply Clean Status Bar Overrides">
                                             <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -115,6 +130,7 @@
                     <connections>
                         <outlet property="bluetoothSegmentedControl" destination="ESw-bP-Eft" id="CvD-yz-7Fk"/>
                         <outlet property="carrierNameTextField" destination="gAn-fq-dJa" id="nxI-oF-1tt"/>
+                        <outlet property="dateStringTextField" destination="SDw-De-k5w" id="hg6-pS-IfR"/>
                         <outlet property="networkSegmentedControl" destination="hoe-iY-qSQ" id="l6m-PF-wMf"/>
                         <outlet property="overrideButton" destination="w0W-Cx-jCM" id="kCn-jU-1yy"/>
                         <outlet property="timeStringTextField" destination="fLD-HZ-npu" id="5BZ-hB-7hl"/>

--- a/SimulatorStatusMagic/ViewController.m
+++ b/SimulatorStatusMagic/ViewController.m
@@ -28,6 +28,7 @@
 @interface ViewController () 
 @property (strong, nonatomic) IBOutlet UIButton *overrideButton;
 @property (strong, nonatomic) IBOutlet UITextField *timeStringTextField;
+@property (strong, nonatomic) IBOutlet UITextField *dateStringTextField;
 @property (strong, nonatomic) IBOutlet UITextField *carrierNameTextField;
 @property (strong, nonatomic) IBOutlet UISegmentedControl *bluetoothSegmentedControl;
 @property (strong, nonatomic) IBOutlet UISegmentedControl *networkSegmentedControl;
@@ -76,6 +77,9 @@
 - (IBAction)timeStringTextFieldEditingChanged:(UITextField *)textField
 {
   [SDStatusBarManager sharedInstance].timeString = textField.text;
+}
+- (IBAction)dateStringTextFieldEditingChanged:(UITextField *)textField {
+	[SDStatusBarManager sharedInstance].dateString = textField.text;
 }
 
 - (IBAction)bluetoothStatusChanged:(UISegmentedControl *)sender
@@ -128,6 +132,11 @@
 - (void)setTimeStringTextFieldText
 {
   self.timeStringTextField.text = [SDStatusBarManager sharedInstance].timeString;
+}
+
+- (void)setDateStringTextFieldText
+{
+  self.dateStringTextField.text = [SDStatusBarManager sharedInstance].dateString;
 }
 
 #pragma mark Status bar settings


### PR DESCRIPTION
I've mostly copy/pasted the time override implementation and tweaked it to work for the date. The localized date format string is a hack (for example, it doesn't work in Chinese because it uses English day of the week names), but I'm not sure what format Apple's using here; hopefully this is good enough as a stopgap.