### PR TITLE
Change canImport to DEBUG check

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -25,14 +25,14 @@ github "shinydevelopment/SimulatorStatusMagic"
 
 5. Add code referencing `SimulatorStatusMagiciOS` inside `#if canImport ... #endif` blocks in your `AppDelegate`:
 ```swift
-#if canImport(SimulatorStatusMagiciOS)
+#if DEBUG
   import SimulatorStatusMagiciOS
 #endif
 
 @UIApplicationMain
 final class AppDelegate: UIResponder, UIApplicationDelegate {
   func application(_ application: UIApplication, didFinishLaunchingWithOptions options: [UIApplication.LaunchOptionsKey: Any]? ) -> Bool {
-    #if canImport(SimulatorStatusMagiciOS)
+    #if DEBUG
       SDStatusBarManager.sharedInstance()?.enableOverrides()
     #endif
   }


### PR DESCRIPTION
In previous usage of the library I had always been using `if DEBUG` however decided to use the `canImport` instead but this caused issues when uploading to the App Store as SimulatorStatusMagic was ending up in my framework search list.

I triple checked everything and the last thing I tried was moving back to `if DEBUG` which stopped it appearing in my framework search path (shown with `otool -L`).

Putting this PR in to hopefully help anyone else who has this issue.