### PR TITLE
Fixes a truncation issue with the override button.

### DIFF
--- a/SimulatorStatusMagic/ViewController.m
+++ b/SimulatorStatusMagic/ViewController.m
@@ -41,6 +41,8 @@
 - (void)viewDidLoad
 {
   [super viewDidLoad];
+  
+  self.overrideButton.titleLabel.adjustsFontSizeToFitWidth = YES;
 
   [self setOverrideButtonText];
   [self setBluetoothSegementedControlSelectedSegment];


### PR DESCRIPTION
There was a bug with the override button text truncating on smaller devices and it bugged me enough to make a pull request 😊 I'll be sad to see this project go, especially considering how buggy the simctl stuff is!

![Simulator Button Truncation Bug](https://user-images.githubusercontent.com/1451896/62840234-044cd480-bc8f-11e9-921b-0226bcdfb5d1.png)
