### PR TITLE
Base the SDStatusBarManagerNetworkTypeKey enum on the integer type that is used in the data struct.

### DIFF
--- a/SDStatusBarManager/SDStatusBarManager.h
+++ b/SDStatusBarManager/SDStatusBarManager.h
@@ -31,7 +31,7 @@ typedef NS_ENUM(NSInteger, SDStatusBarManagerBluetoothState)
   SDStatusBarManagerBluetoothVisibleConnected
 };
 
-typedef NS_ENUM(NSInteger, SDStatusBarManagerNetworkType)
+typedef NS_ENUM(unsigned int, SDStatusBarManagerNetworkType)
 {
   SDStatusBarManagerNetworkTypeWiFi = 0,
   SDStatusBarManagerNetworkTypeGPRS,

--- a/SDStatusBarManager/SDStatusBarManager.m
+++ b/SDStatusBarManager/SDStatusBarManager.m
@@ -127,7 +127,7 @@ static NSString * const SDStatusBarManagerDateStringKey = @"date_string";
 
 - (SDStatusBarManagerNetworkType)networkType
 {
-  return [[self.userDefaults valueForKey:SDStatusBarManagerNetworkTypeKey] integerValue];
+  return [[self.userDefaults valueForKey:SDStatusBarManagerNetworkTypeKey] unsignedIntValue];
 }
 
 - (void)setCarrierName:(NSString *)carrierName


### PR DESCRIPTION
Fixes warnings introduced in Xcode 12.

A little bit of a different approach than that in https://github.com/shinydevelopment/SimulatorStatusMagic/pull/90, by just using `unsigned int` as the base type for the enum. I don't think it will actually behave any differently, but avoids having to cast everywhere, and more clearly shows that the enum is expected to fit in an `unsigned int`.