### PR TITLE
Add support for iOS 16

### DIFF
--- a/SDStatusBarManager/SDStatusBarManager.m
+++ b/SDStatusBarManager/SDStatusBarManager.m
@@ -35,6 +35,7 @@
 #import "SDStatusBarOverriderPost13_0.h"
 #import "SDStatusBarOverriderPost14_0.h"
 #import "SDStatusBarOverriderPost15_0.h"
+#import "SDStatusBarOverriderPost16_0.h"
 
 static NSString * const SDStatusBarManagerUsingOverridesKey = @"using_overrides";
 static NSString * const SDStatusBarManagerBluetoothStateKey = @"bluetooth_state";
@@ -190,7 +191,9 @@ static NSString * const SDStatusBarManagerDateStringKey = @"date_string";
 {
   id<SDStatusBarOverrider> overrider = nil;
   NSProcessInfo *pi = [NSProcessInfo processInfo];
-  if ([pi isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){ 15, 0, 0 }]) {
+  if ([pi isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){ 16, 0, 0 }]) {
+    overrider = [SDStatusBarOverriderPost16_0 new];
+  } else if ([pi isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){ 15, 0, 0 }]) {
     overrider = [SDStatusBarOverriderPost15_0 new];
   } else if ([pi isOperatingSystemAtLeastVersion:(NSOperatingSystemVersion){ 14, 0, 0 }]) {
     overrider = [SDStatusBarOverriderPost14_0 new];

--- a/SDStatusBarManager/SDStatusBarOverriderPost16_0.h
+++ b/SDStatusBarManager/SDStatusBarOverriderPost16_0.h
@@ -1,0 +1,18 @@
+//
+//  SDStatusBarOverriderPost16_0.h
+//  SimulatorStatusMagic
+//
+//  Created by Chris Vasselli on 10/14/20.
+//  Copyright © 2020 Shiny Development. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "SDStatusBarOverrider.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface SDStatusBarOverriderPost16_0 : NSObject <SDStatusBarOverrider>
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/SDStatusBarManager/SDStatusBarOverriderPost16_0.m
+++ b/SDStatusBarManager/SDStatusBarOverriderPost16_0.m
@@ -118,7 +118,7 @@ typedef struct {
   char primaryServiceBadgeString[100];
   char secondaryServiceBadgeString[100];
   char quietModeImage[256];
-  unsigned int extra1 : 1; // Unsure of actual size, but it's at least 1 byte. If it's actually larger, we are probably sending garbage from whatever sits after the StatusBarOverrideData struct in memory into the status bar server. But since we are setting itemIsEnabled[Extra1StatusBarItem] to 0, I'm guessing that whatever is getting passed into this is going unused... probably.
+  unsigned int extra1 : 1; // Unsure of actual size, but it's at least 1 byte. Since this is at the end of the struct, and we aren't modifying this part of the struct, it likely shouldn't matter that it's not the correct size.
 } StatusBarRawData;
 
 typedef struct {

--- a/SDStatusBarManager/SDStatusBarOverriderPost16_0.m
+++ b/SDStatusBarManager/SDStatusBarOverriderPost16_0.m
@@ -1,0 +1,313 @@
+//
+//  SDStatusBarOverriderPost16_0.m
+//  SimulatorStatusMagic
+//
+//  Created by Chris Vasselli on 10/14/20.
+//  Copyright © 2020 Shiny Development. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "SDStatusBarOverriderPost16_0.h"
+
+typedef NS_ENUM(int, StatusBarItem) {
+  TimeStatusBarItem = 0,
+  DateStatusBarItem = 1,
+  QuietModeStatusBarItem = 2,
+  AirplaneModeStatusBarItem = 3,
+  CellularSignalStrengthStatusBarItem = 4,
+  SecondaryCellularSignalStrengthStatusBarItem = 5,
+  CellularServiceStatusBarItem = 6,
+  SecondaryCellularServiceStatusBarItem = 7,
+  // 8
+  CellularDataNetworkStatusBarItem = 9,
+  SecondaryCellularDataNetworkStatusBarItem = 10,
+  // 11
+  MainBatteryStatusBarItem = 12,
+  ProminentlyShowBatteryDetailStatusBarItem = 13,
+  // 14
+  // 15
+  BluetoothStatusBarItem = 16,
+  TTYStatusBarItem = 17,
+  AlarmStatusBarItem = 18,
+  // 19
+  // 20
+  LocationStatusBarItem = 21,
+  RotationLockStatusBarItem = 22,
+  // 23
+  AirPlayStatusBarItem = 24,
+  AssistantStatusBarItem = 25,
+  CarPlayStatusBarItem = 26,
+  StudentStatusBarItem = 27,
+  VPNStatusBarItem = 28,
+  // 29
+  // 30
+  // 31
+  // 32
+  // 33
+  // 34
+  // 35
+  // 36
+  // 37
+  LiquidDetectionStatusBarItem = 38,
+  VoiceControlStatusBarItem = 39,
+  // 40
+  // 41
+  // 42
+  // 43
+  Extra1StatusBarItem = 44,
+};
+
+typedef NS_ENUM(unsigned int, BatteryState) {
+  BatteryStateUnplugged = 0
+};
+
+
+typedef struct {
+  bool itemIsEnabled[45];
+  char timeString[64];
+  char shortTimeString[64];
+  char dateString[256];
+  int gsmSignalStrengthRaw;
+  int secondaryGsmSignalStrengthRaw;
+  int gsmSignalStrengthBars;
+  int secondaryGsmSignalStrengthBars;
+  char serviceString[100];
+  char secondaryServiceString[100];
+  char serviceCrossfadeString[100];
+  char secondaryServiceCrossfadeString[100];
+  char serviceImages[2][100];
+  char operatorDirectory[1024];
+  unsigned int serviceContentType;
+  unsigned int secondaryServiceContentType;
+  unsigned int cellLowDataModeActive:1;
+  unsigned int secondaryCellLowDataModeActive:1;
+  int wifiSignalStrengthRaw;
+  int wifiSignalStrengthBars;
+  unsigned int wifiLowDataModeActive:1;
+  unsigned int dataNetworkType;
+  unsigned int secondaryDataNetworkType;
+  int batteryCapacity;
+  unsigned int batteryState;
+  char batteryDetailString[150];
+  int bluetoothBatteryCapacity;
+  int thermalColor;
+  unsigned int thermalSunlightMode : 1;
+  unsigned int slowActivity : 1;
+  unsigned int syncActivity : 1;
+  char activityDisplayId[256];
+  unsigned int bluetoothConnected : 1;
+  unsigned int displayRawGSMSignal : 1;
+  unsigned int displayRawWifiSignal : 1;
+  unsigned int locationIconType : 1;
+  unsigned int voiceControlIconType:2;
+  unsigned int quietModeInactive : 1;
+  unsigned int tetheringConnectionCount;
+  unsigned int batterySaverModeActive : 1;
+  unsigned int deviceIsRTL : 1;
+  unsigned int lock : 1;
+  char breadcrumbTitle[256];
+  char breadcrumbSecondaryTitle[256];
+  char personName[100];
+  unsigned int electronicTollCollectionAvailable : 1;
+  unsigned int radarAvailable : 1;
+  unsigned int wifiLinkWarning : 1;
+  unsigned int wifiSearching : 1;
+  double backgroundActivityDisplayStartDate;
+  unsigned int shouldShowEmergencyOnlyStatus : 1;
+  unsigned int secondaryCellularConfigured : 1;
+  char primaryServiceBadgeString[100];
+  char secondaryServiceBadgeString[100];
+  char quietModeImage[256];
+  unsigned int extra1 : 1; // Unsure of actual size, but it's at least 1 byte. If it's actually larger, we are probably sending garbage from whatever sits after the StatusBarOverrideData struct in memory into the status bar server. But since we are setting itemIsEnabled[Extra1StatusBarItem] to 0, I'm guessing that whatever is getting passed into this is going unused... probably.
+} StatusBarRawData;
+
+typedef struct {
+  bool overrideItemIsEnabled[45];
+  unsigned int overrideTimeString : 1;
+  unsigned int overrideDateString : 1;
+  unsigned int overrideGsmSignalStrengthRaw : 1;
+  unsigned int overrideSecondaryGsmSignalStrengthRaw : 1;
+  unsigned int overrideGsmSignalStrengthBars : 1;
+  unsigned int overrideSecondaryGsmSignalStrengthBars : 1;
+  unsigned int overrideServiceString : 1;
+  unsigned int overrideSecondaryServiceString : 1;
+  unsigned int overrideServiceImages : 2;
+  unsigned int overrideOperatorDirectory : 1;
+  unsigned int overrideServiceContentType : 1;
+  unsigned int overrideSecondaryServiceContentType : 1;
+  unsigned int overrideWifiSignalStrengthRaw : 1;
+  unsigned int overrideWifiSignalStrengthBars : 1;
+  unsigned int overrideDataNetworkType : 1;
+  unsigned int overrideSecondaryDataNetworkType : 1;
+  unsigned int disallowsCellularDataNetworkTypes : 1;
+  unsigned int overrideBatteryCapacity : 1;
+  unsigned int overrideBatteryState : 1;
+  unsigned int overrideBatteryDetailString : 1;
+  unsigned int overrideBluetoothBatteryCapacity : 1;
+  unsigned int overrideThermalColor : 1;
+  unsigned int overrideSlowActivity : 1;
+  unsigned int overrideActivityDisplayId : 1;
+  unsigned int overrideBluetoothConnected : 1;
+  unsigned int overrideBreadcrumb : 1;
+  unsigned int overrideLock;
+  unsigned int overrideDisplayRawGSMSignal : 1;
+  unsigned int overrideDisplayRawWifiSignal : 1;
+  unsigned int overridePersonName : 1;
+  unsigned int overrideWifiLinkWarning : 1;
+  unsigned int overrideSecondaryCellularConfigured : 1;
+  unsigned int overridePrimaryServiceBadgeString : 1;
+  unsigned int overrideSecondaryServiceBadgeString : 1;
+  unsigned int overrideQuietModeImage : 1;
+  unsigned int overrideExtra1 : 1; // Not sure what this is, but there only seems to be one of them
+  StatusBarRawData values;
+} StatusBarOverrideData;
+
+@class UIStatusBarServer;
+
+@protocol UIStatusBarServerClient
+
+@required
+
+- (void)statusBarServer:(UIStatusBarServer *)arg1 didReceiveDoubleHeightStatusString:(NSString *)arg2 forStyle:(long long)arg3;
+- (void)statusBarServer:(UIStatusBarServer *)arg1 didReceiveGlowAnimationState:(bool)arg2 forStyle:(long long)arg3;
+- (void)statusBarServer:(UIStatusBarServer *)arg1 didReceiveStatusBarData:(const StatusBarRawData *)arg2 withActions:(int)arg3;
+- (void)statusBarServer:(UIStatusBarServer *)arg1 didReceiveStyleOverrides:(int)arg2;
+
+@end
+
+@interface UIStatusBarServer : NSObject
+
+@property (nonatomic, strong) id<UIStatusBarServerClient> statusBar;
+
++ (void)postStatusBarOverrideData:(StatusBarOverrideData *)arg1;
++ (void)permanentizeStatusBarOverrideData;
++ (StatusBarOverrideData *)getStatusBarOverrideData;
+
+@end
+
+@implementation SDStatusBarOverriderPost16_0
+
+@synthesize timeString;
+@synthesize dateString;
+@synthesize carrierName;
+@synthesize bluetoothConnected;
+@synthesize bluetoothEnabled;
+@synthesize batteryDetailEnabled;
+@synthesize networkType;
+@synthesize iPadDateEnabled;
+@synthesize iPadGsmSignalEnabled;
+
+- (void)enableOverrides {
+  StatusBarOverrideData *overrides = [UIStatusBarServer getStatusBarOverrideData];
+
+  // Set 9:41 time in current localization
+  strcpy(overrides->values.timeString, [self.timeString cStringUsingEncoding:NSUTF8StringEncoding]);
+  overrides->overrideTimeString = 1;
+  
+  // Set Tue Jan 9 in current localization
+  strcpy(overrides->values.dateString, [self.dateString cStringUsingEncoding:NSUTF8StringEncoding]);
+  overrides->overrideDateString = 1;
+  
+  // Show / Hide date on iPad
+  if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+    overrides->overrideItemIsEnabled[DateStatusBarItem] = 1;
+    overrides->values.itemIsEnabled[DateStatusBarItem] = self.iPadDateEnabled ? 1 : 0;
+  }
+
+  // Enable 5 bars of mobile (iPhone only)
+  if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPhone) {
+    overrides->overrideItemIsEnabled[CellularSignalStrengthStatusBarItem] = 1;
+    overrides->values.itemIsEnabled[CellularSignalStrengthStatusBarItem] = 1;
+    overrides->overrideGsmSignalStrengthBars = 1;
+    overrides->values.gsmSignalStrengthBars = 5;
+  }
+  
+  // Enable / Disable GSM signal bars on iPad
+  if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+    if (self.iPadGsmSignalEnabled) {
+      overrides->overrideItemIsEnabled[CellularSignalStrengthStatusBarItem] = 1;
+      overrides->values.itemIsEnabled[CellularSignalStrengthStatusBarItem] = 1;
+      overrides->overrideGsmSignalStrengthBars = 1;
+      overrides->values.gsmSignalStrengthBars = 5;
+    } else {
+      overrides->overrideItemIsEnabled[CellularSignalStrengthStatusBarItem] = 1;
+      overrides->values.itemIsEnabled[CellularSignalStrengthStatusBarItem] = 0;
+    }
+  }
+
+  overrides->overrideDataNetworkType = self.networkType != SDStatusBarManagerNetworkTypeWiFi;
+  overrides->values.dataNetworkType = self.networkType - 1;
+
+  // Remove carrier text for iPhone, set it to "iPad" for the iPad
+  overrides->overrideServiceString = 1;
+  NSString *carrierText = self.carrierName;
+  if ([carrierText length] <= 0) {
+    carrierText = ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPhone) ? @"" : @"iPad";
+  }
+  strcpy(overrides->values.serviceString, [carrierText cStringUsingEncoding:NSUTF8StringEncoding]);
+
+  // Battery: 100% and unplugged
+  overrides->overrideItemIsEnabled[ProminentlyShowBatteryDetailStatusBarItem] = YES;
+  overrides->values.itemIsEnabled[ProminentlyShowBatteryDetailStatusBarItem] = self.batteryDetailEnabled;
+  overrides->overrideBatteryCapacity = YES;
+  overrides->values.batteryCapacity = 100;
+  overrides->overrideBatteryState = YES;
+  overrides->values.batteryState = BatteryStateUnplugged;
+  overrides->overrideBatteryDetailString = YES;
+  NSString *batteryDetailString = [NSString stringWithFormat:@"%@%%", @(overrides->values.batteryCapacity)];
+  strcpy(overrides->values.batteryDetailString, [batteryDetailString cStringUsingEncoding:NSUTF8StringEncoding]);
+
+  // Bluetooth
+  overrides->overrideItemIsEnabled[BluetoothStatusBarItem] = !!self.bluetoothEnabled;
+  overrides->values.itemIsEnabled[BluetoothStatusBarItem] = !!self.bluetoothEnabled;
+  if (self.bluetoothEnabled) {
+    overrides->overrideBluetoothConnected = self.bluetoothConnected;
+    overrides->values.bluetoothConnected = self.bluetoothConnected;
+  }
+
+  overrides->overrideItemIsEnabled[AirPlayStatusBarItem] = YES;
+  overrides->values.itemIsEnabled[AirPlayStatusBarItem] = NO;
+    
+  overrides->overrideItemIsEnabled[Extra1StatusBarItem] = YES;
+  overrides->values.itemIsEnabled[Extra1StatusBarItem] = NO;
+    
+
+  // Actually update the status bar
+  [UIStatusBarServer postStatusBarOverrideData:overrides];
+
+  // Lock in the changes, reset simulator will remove this
+  [UIStatusBarServer permanentizeStatusBarOverrideData];
+    
+    
+    
+}
+
+- (void)disableOverrides {
+  StatusBarOverrideData *overrides = [UIStatusBarServer getStatusBarOverrideData];
+
+  // Remove all overrides that use the array of bools
+  bzero(overrides->overrideItemIsEnabled, sizeof(overrides->overrideItemIsEnabled));
+  bzero(overrides->values.itemIsEnabled, sizeof(overrides->values.itemIsEnabled));
+
+  // Remove specific overrides (separate flags)
+  overrides->overrideTimeString = 0;
+  overrides->overrideDateString = 0;
+  overrides->overrideGsmSignalStrengthBars = 0;
+  overrides->overrideDataNetworkType = 0;
+  overrides->overrideBatteryCapacity = 0;
+  overrides->overrideBatteryState = 0;
+  overrides->overrideBatteryDetailString = 0;
+  overrides->overrideBluetoothConnected = 0;
+
+  // Carrier text (it's an override to set it back to the default)
+  overrides->overrideServiceString = 1;
+  strcpy(overrides->values.serviceString, [NSLocalizedString(@"Carrier", @"Carrier") cStringUsingEncoding:NSUTF8StringEncoding]);
+
+  // Actually update the status bar
+  [UIStatusBarServer postStatusBarOverrideData:overrides];
+
+  // Have to call this to remove all the overrides
+  [UIStatusBarServer permanentizeStatusBarOverrideData];
+}
+
+@end

--- a/SimulatorStatusMagic.xcodeproj/project.pbxproj
+++ b/SimulatorStatusMagic.xcodeproj/project.pbxproj
@@ -57,6 +57,9 @@
 		8301C2F02674190900557F0B /* SDStatusBarOverriderPost15_0.m in Sources */ = {isa = PBXBuildFile; fileRef = 8301C2EE2674190900557F0B /* SDStatusBarOverriderPost15_0.m */; };
 		8301C2F12674190900557F0B /* SDStatusBarOverriderPost15_0.h in Headers */ = {isa = PBXBuildFile; fileRef = 8301C2EF2674190900557F0B /* SDStatusBarOverriderPost15_0.h */; };
 		8301C2F22674191000557F0B /* SDStatusBarOverriderPost15_0.m in Sources */ = {isa = PBXBuildFile; fileRef = 8301C2EE2674190900557F0B /* SDStatusBarOverriderPost15_0.m */; };
+		83F6B55E28ADED1100F91126 /* SDStatusBarOverriderPost16_0.m in Sources */ = {isa = PBXBuildFile; fileRef = 83F6B55C28ADED1100F91126 /* SDStatusBarOverriderPost16_0.m */; };
+		83F6B55F28ADED1100F91126 /* SDStatusBarOverriderPost16_0.m in Sources */ = {isa = PBXBuildFile; fileRef = 83F6B55C28ADED1100F91126 /* SDStatusBarOverriderPost16_0.m */; };
+		83F6B56028ADED1100F91126 /* SDStatusBarOverriderPost16_0.h in Headers */ = {isa = PBXBuildFile; fileRef = 83F6B55D28ADED1100F91126 /* SDStatusBarOverriderPost16_0.h */; };
 		B7C0DC072577DC4D0072F6D4 /* SDStatusBarOverriderPost14_0.h in Headers */ = {isa = PBXBuildFile; fileRef = B7C0DC052577DC4D0072F6D4 /* SDStatusBarOverriderPost14_0.h */; };
 		B7C0DC082577DC4D0072F6D4 /* SDStatusBarOverriderPost14_0.m in Sources */ = {isa = PBXBuildFile; fileRef = B7C0DC062577DC4D0072F6D4 /* SDStatusBarOverriderPost14_0.m */; };
 		B7C0DC092577DC4D0072F6D4 /* SDStatusBarOverriderPost14_0.m in Sources */ = {isa = PBXBuildFile; fileRef = B7C0DC062577DC4D0072F6D4 /* SDStatusBarOverriderPost14_0.m */; };
@@ -124,6 +127,8 @@
 		72ECF7291BAAC33A0071D401 /* SimulatorStatusMagiciOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SimulatorStatusMagiciOS.h; sourceTree = "<group>"; };
 		8301C2EE2674190900557F0B /* SDStatusBarOverriderPost15_0.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDStatusBarOverriderPost15_0.m; sourceTree = "<group>"; };
 		8301C2EF2674190900557F0B /* SDStatusBarOverriderPost15_0.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDStatusBarOverriderPost15_0.h; sourceTree = "<group>"; };
+		83F6B55C28ADED1100F91126 /* SDStatusBarOverriderPost16_0.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDStatusBarOverriderPost16_0.m; sourceTree = "<group>"; };
+		83F6B55D28ADED1100F91126 /* SDStatusBarOverriderPost16_0.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDStatusBarOverriderPost16_0.h; sourceTree = "<group>"; };
 		B7C0DC052577DC4D0072F6D4 /* SDStatusBarOverriderPost14_0.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SDStatusBarOverriderPost14_0.h; sourceTree = "<group>"; };
 		B7C0DC062577DC4D0072F6D4 /* SDStatusBarOverriderPost14_0.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SDStatusBarOverriderPost14_0.m; sourceTree = "<group>"; };
 		DB9638001D6E24C9002F122B /* SDStatusBarOverriderPost10_0.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SDStatusBarOverriderPost10_0.h; sourceTree = "<group>"; };
@@ -250,6 +255,8 @@
 				B7C0DC062577DC4D0072F6D4 /* SDStatusBarOverriderPost14_0.m */,
 				8301C2EF2674190900557F0B /* SDStatusBarOverriderPost15_0.h */,
 				8301C2EE2674190900557F0B /* SDStatusBarOverriderPost15_0.m */,
+				83F6B55D28ADED1100F91126 /* SDStatusBarOverriderPost16_0.h */,
+				83F6B55C28ADED1100F91126 /* SDStatusBarOverriderPost16_0.m */,
 			);
 			path = SDStatusBarManager;
 			sourceTree = SOURCE_ROOT;
@@ -269,6 +276,7 @@
 				72ECF74A1BAAC3580071D401 /* SDStatusBarOverriderPre8_3.h in Headers */,
 				72ECF74B1BAAC3580071D401 /* SDStatusBarOverriderPost8_3.h in Headers */,
 				3D97737422A6615C0031C416 /* SDStatusBarOverriderPost13_0.h in Headers */,
+				83F6B56028ADED1100F91126 /* SDStatusBarOverriderPost16_0.h in Headers */,
 				72ECF74C1BAAC3580071D401 /* SDStatusBarOverriderPost9_0.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -402,6 +410,7 @@
 				552D9BAA1CA69D39002B6644 /* SDStatusBarOverriderPost9_3.m in Sources */,
 				B7C0DC082577DC4D0072F6D4 /* SDStatusBarOverriderPost14_0.m in Sources */,
 				448EAEAA1B3B326100A09FBC /* SDStatusBarOverriderPost9_0.m in Sources */,
+				83F6B55E28ADED1100F91126 /* SDStatusBarOverriderPost16_0.m in Sources */,
 				DDACF30B19E83F06004FCB30 /* SDStatusBarManager.m in Sources */,
 				3D97737222A6615C0031C416 /* SDStatusBarOverriderPost13_0.m in Sources */,
 				5516356E19E3FF3D001F636D /* main.m in Sources */,
@@ -421,6 +430,7 @@
 				72ECF7441BAAC34E0071D401 /* SDStatusBarManager.m in Sources */,
 				8301C2F02674190900557F0B /* SDStatusBarOverriderPost15_0.m in Sources */,
 				449C2C801E8AB839002D3846 /* SDStatusBarOverriderPost10_3.m in Sources */,
+				83F6B55F28ADED1100F91126 /* SDStatusBarOverriderPost16_0.m in Sources */,
 				441955851F15330D00F1F39B /* SDStatusBarOverriderPost11_0.m in Sources */,
 				72ECF7451BAAC34E0071D401 /* SDStatusBarOverriderPre8_3.m in Sources */,
 				3D97737322A6615C0031C416 /* SDStatusBarOverriderPost13_0.m in Sources */,


### PR DESCRIPTION
This is based on trial and error to figure out the size of the new structs, because `dsdump` is still crashing on the iOS 16 UIKitCore binary, so I have not figured out a way to see what the struct actually looks like.

It seems clear that one new item has been added to the overrides struct, which I have called "extra1".  I have not figured out any way to determine definitively the size of the data it is expecting in `StatusBarRawData`, but I don't _think_ it should matter. The new item seems to correspond to [this new icon in the status bar](https://i.imgur.com/oN1x6NY.png).

I would love a second opinion on this, but I think that because we are getting this struct from a call to `[UIStatusBarServer getStatusBarOverrideData]`, modifying it, and then passing it back via `[UIStatusBarServer postStatusBarOverrideData:overrides]`, I don't think the fact that our `StatusBarRawData` struct is probably the wrong size should matter. It is at the tail end of the struct, and we are not modifying that part of the struct anyway. The only thing I can imagine causing problems would be if for some reason the difference in the shape of the end of the struct would cause the compiler to store the data at the beginning of the struct in a different way. If that were the case, perhaps our modifications to other parts of the struct could place data in the wrong place. But it seems like this is unlikely, and in practice it seems that things are working fine.
