### PR TITLE
Allow running `build_and_inject.sh` from anywhere

### DIFF
--- a/build_and_inject.sh
+++ b/build_and_inject.sh
@@ -1,3 +1,4 @@
+cd "$(dirname "$0")"
 xcodebuild -scheme "SimulatorStatusMagicDlib" -sdk iphonesimulator -derivedDataPath build
 xcrun simctl spawn $1 launchctl debug system/com.apple.SpringBoard --environment DYLD_INSERT_LIBRARIES="$PWD/build/Build/Products/Debug-iphonesimulator/libSimulatorStatusMagicDlib.dylib"
 xcrun simctl spawn $1 launchctl stop com.apple.SpringBoard


### PR DESCRIPTION
Currently, the `build_and_inject.sh` script requires that it be ran exactly from the root of this repo. However, this is not very convenient for integration where scripts are ran from a parent directory. This simple addition allows the script to be ran from anywhere.