### PR TITLE
XCTest simulator version of build_and_inject

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,15 +11,18 @@ Modify the iOS Simulator so that it has a perfect status bar, then run your app 
 
 Starting in Xcode 11, the `simctl` command line tool includes a `status_bar` option that allows you to override the appearance of the status bar in the simulator. Hopefully this will eventually supercede the need for SimulatorStatusMagic, but at the moment it still has holes that make this project continue to be relevant. In particular, `simctl status_bar` does not currently provide a way to add localized date and time strings in the status bar.
 
-## 1) Injecting into Springboard (Required on iOS 17+)
-**tl;dr** Running `build_and_inject.sh booted` will apply a default status bar to the running simulator. Replace "booted" with a simulator UDID to target a specific simulator.
+## Usage
+
+### 1) Injecting into Springboard (Required on iOS 17+)
+**tl;dr** Running `build_and_inject.sh booted` will apply a default status bar to the running simulator. Replace "booted" with a simulator UDID to target a specific simulator. Retrieve them with `xcrun simctl list devices | grep 'Booted'`
+
+**For XCTest simulators, use `build_and_inject_test.sh booted`** - Replace "booted" with a simulator UDID to target a specific simulator. Retrieve them with `xcrun simctl --set testing list devices | grep 'Booted'`
 
 As of iOS 17, the API used by SimulatorStatusMagic is not accessible to processes other than Springboard. So, in iOS 17+ we need to inject SimulatorStatusMagic into the Springboard process itself, which we do by building it as a dynamic library, and then updating Springboard's launchd configuration to load our dynamic library.
 
 Running `build_and_inject.sh` will do all of this for you. If you want to change anything about the values used in the status bar, you will need to update DynamicLibrary/main.m.
 
-
-## 2) Using in screenshot automation UI Tests
+### 2) Using in screenshot automation UI Tests (iOS 16 and lower)
 - Add the swift package in xcode using the repository url (https://github.com/shinydevelopment/SimulatorStatusMagic)
 - Select your UI Test target when asked what target to add it to
 - Call the following in your tests:
@@ -46,7 +49,7 @@ final class YourUITests: XCTestCase {
 It is recommended to **only** include `SDStatusBarManager` in your debug configuration so that the code is **never** included in release builds. When you want to apply a perfect status bar, call `[[SDStatusBarManager sharedInstance] enableOverrides]`. To restore the standard status bar, call `[[SDStatusBarManager sharedInstance] disableOverrides]`.
 
 
-## 3) Using the demo app to enable/disable overrides
+### 3) Using the demo app to enable/disable overrides (iOS 16 and lower)
 
 * Clone this repository.
 * Open SimulatorStatusMagic.xcodeproj with Xcode 6 (or above).

--- a/build_and_inject_test.sh
+++ b/build_and_inject_test.sh
@@ -1,0 +1,6 @@
+cd "$(dirname "$0")"
+xcodebuild -scheme "SimulatorStatusMagicDlib" -sdk iphonesimulator -derivedDataPath build
+
+# Set testing to detect XCTest simulators
+xcrun simctl --set testing spawn $1 launchctl debug system/com.apple.SpringBoard --environment DYLD_INSERT_LIBRARIES="$PWD/build/Build/Products/Debug-iphonesimulator/libSimulatorStatusMagicDlib.dylib"
+xcrun simctl --set testing spawn $1 launchctl stop com.apple.SpringBoard


### PR DESCRIPTION
I was automating screenshots with XCTest and the normal version of the build_and_inject script didn't find the Clone simulator(s) that opens.

--set testing will show the simulators used there, added a separate file for it.